### PR TITLE
Update usable_skill.lua

### DIFF
--- a/lua/lunarltk/core/skill_type/usable_skill.lua
+++ b/lua/lunarltk/core/skill_type/usable_skill.lua
@@ -30,7 +30,9 @@ end
 function UsableSkill:getMaxUseTime(player, scope, card, to)
   scope = scope or Player.HistoryTurn
   local ret = self.max_use_time[scope]
-  if not ret then return nil end
+  if not ret then return nil
+  elseif type(ret) == 'function' then ret = ret(self, player)
+  end
   if card then
     local status_skills = Fk:currentRoom().status_skills[TargetModSkill] or Util.DummyTable
     for _, skill in ipairs(status_skills) do


### PR DESCRIPTION
考虑函数形式的self.max_use_time[scope]（与skill_skeleton.lua及fk_ex.lua中的声明匹配，即未引入参量to）