### PR TITLE
使用ActiveSkill:withinDistanceLimit(player: Player, isattack: boolean?, card: Card, to: Player)时card该填啥？新月似乎不讲技能卡

### DIFF
--- a/lua/lunarltk/core/skill_type/active.lua
+++ b/lua/lunarltk/core/skill_type/active.lua
@@ -32,7 +32,7 @@ end
 ---@param extra_data? UseExtraData @ 额外数据
 ---@return boolean?
 function ActiveSkill:canUse(player, card, extra_data)
-  return self:isEffectable(player) and self:withinTimesLimit(player, Player.HistoryPhase, card)
+  return ((self.is_delay_effect or self:isEffectable(player)) and self:withinTimesLimit(player, Player.HistoryPhase, card)) --self:isEffectable(player) and
 end
 
 --- 判断一张牌是否可被此技能选中
@@ -164,7 +164,8 @@ end
 ---@param to Player @ 目标
 ---@return boolean?
 function ActiveSkill:withinDistanceLimit(player, isattack, card, to)
-  if not to or player:distanceTo(to, nil, nil, table.connect(Card:getIdList(card), card.fake_subcards), nil, card) < 1 then return false end
+  if (not to) or to.dead or (player.id == to.id) then return false end
+  local d = card and player:distanceTo(to, nil, nil, table.connect(Card:getIdList(card), card.fake_subcards), nil, card) or player:distanceTo(to)
   local status_skills = Fk:currentRoom().status_skills[TargetModSkill] or Util.DummyTable
   if not card and self.name:endsWith("_skill") then
     card = Fk:cloneCard(self.name:sub(1, #self.name - 6))
@@ -174,7 +175,7 @@ function ActiveSkill:withinDistanceLimit(player, isattack, card, to)
   end
 
   return (isattack and player:inMyAttackRange(to, nil, table.connect(Card:getIdList(card), card.fake_subcards), nil, card)) or
-  (player:distanceTo(to, nil, nil, table.connect(Card:getIdList(card), card.fake_subcards), nil, card) <= self:getDistanceLimit(player, card, to)) or
+  ((d > 0) and (d <= self:getDistanceLimit(player, card, to))) or
   not not card:hasMark(MarkEnum.BypassDistancesLimit) or
   not not player:hasMark(MarkEnum.BypassDistancesLimit) or
   not not to:hasMark(MarkEnum.BypassDistancesLimitTo)

--- a/lua/lunarltk/core/skill_type/active.lua
+++ b/lua/lunarltk/core/skill_type/active.lua
@@ -174,7 +174,7 @@ function ActiveSkill:withinDistanceLimit(player, isattack, card, to)
     if skill:bypassDistancesCheck(player, self, card, to) then return true end
   end
 
-  return (isattack and player:inMyAttackRange(to, nil, table.connect(Card:getIdList(card), card.fake_subcards), nil, card)) or
+  return (isattack and player:inMyAttackRange(to, nil, table.connect(Card:getIdList(card), card and card.fake_subcards or {}), nil, card)) or
   ((d > 0) and (d <= self:getDistanceLimit(player, card, to))) or
   not not card:hasMark(MarkEnum.BypassDistancesLimit) or
   not not player:hasMark(MarkEnum.BypassDistancesLimit) or

--- a/lua/lunarltk/core/skill_type/cardskill.lua
+++ b/lua/lunarltk/core/skill_type/cardskill.lua
@@ -197,7 +197,8 @@ end
 ---@param to Player @ 目标
 ---@return boolean?
 function CardSkill:withinDistanceLimit(player, isattack, card, to)
-  if not to or player:distanceTo(to, nil, nil, table.connect(Card:getIdList(card), card.fake_subcards), nil, card) < 1 then return false end
+  if (not to) or to.dead or (player.id == to.id) then return false end
+  local d = card and player:distanceTo(to, nil, nil, table.connect(Card:getIdList(card), card.fake_subcards), nil, card) or player:distanceTo(to)
   local status_skills = Fk:currentRoom().status_skills[TargetModSkill] or Util.DummyTable
   if not card and self.name:endsWith("_skill") then
     card = Fk:cloneCard(self.name:sub(1, #self.name - 6))
@@ -207,7 +208,7 @@ function CardSkill:withinDistanceLimit(player, isattack, card, to)
   end
 
   return (isattack and player:inMyAttackRange(to, nil, table.connect(Card:getIdList(card), card.fake_subcards), nil, card)) or
-  (player:distanceTo(to, nil, nil, table.connect(Card:getIdList(card), card.fake_subcards), nil, card) <= self:getDistanceLimit(player, card, to)) or
+  ((d > 0) and (d <= self:getDistanceLimit(player, card, to))) or
   not not card:hasMark(MarkEnum.BypassDistancesLimit) or
   not not player:hasMark(MarkEnum.BypassDistancesLimit) or
   not not to:hasMark(MarkEnum.BypassDistancesLimitTo)


### PR DESCRIPTION
修复withinDistanceLimit中card参量为nil时取fake_subcards的错误并兼容仅不计入距离的计算（无距离关系的限制则不怕）；修复ActiveSkill实为延时类效果时仍会被无效化的错误